### PR TITLE
fixes issue with php 8 and get_class_methods() on null

### DIFF
--- a/src/Support/PersistResource.php
+++ b/src/Support/PersistResource.php
@@ -147,11 +147,11 @@ class PersistResource
             foreach ($resource as $field => $rules) {
                 if ($this->hasRelation($key)) {
                     $relation = $this->getRelation($key)->type;
-                } elseif (method_exists($this->object, $key)) {
+                } elseif (!is_null($this->object) && method_exists($this->object, $key)) {
                     $relation = $this->object->$key()->type;
-                } elseif (method_exists($this->object, Str::studly($key))) {
+                } elseif (!is_null($this->object) && method_exists($this->object, Str::studly($key))) {
                     $relation = $this->object->{Str::studly($key)}()->type;
-                } elseif (method_exists($this->object, lcfirst($key))) {
+                } elseif (!is_null($this->object) && method_exists($this->object, lcfirst($key))) {
                     $relation = $this->object->{lcfirst($key)}()->type;
                 } else {
                     $relation = 'HasOne';


### PR DESCRIPTION
We get an issue after Updating to php 8:

`production.ERROR: method_exists(): Argument #1 ($object_or_class) must be of type object|string, null given {"userId":1,"exception":"[object] (TypeError(code: 0): method_exists(): Argument #1 ($object_or_class) must be of type object|string, null given at vendor/macsidigital/laravel-api-client/src/Support/PersistResource.php:150)`

I added null-checks which are solving the problem for us. We tested our zoom integration with the fix and got the same behaviour as we had before the php 8 upgrade.