### PR TITLE
Update InteractsWithAPI.php

### DIFF
--- a/src/Traits/InteractsWithAPI.php
+++ b/src/Traits/InteractsWithAPI.php
@@ -529,12 +529,13 @@ trait InteractsWithAPI
         if (! $this->hasKey()) {
             return;
         }
-        $this->beforeDeleting();
+
+        $this->beforeDeleting($query);
 
         $response = $query->delete();
 
         if ($response) {
-            $this->afterDeleting();
+            $this->afterDeleting($query);
         }
 
         return $response;


### PR DESCRIPTION
If the resource does not override standard provided `delete()` method, it fails with `TypeError: Too few arguments to function MacsiDigital\API\Support\ApiResource::beforeDeleting()`

specific example: 
[MacsiDigital\LaravelZoomWebinar](https://github.com/MacsiDigital/laravel-zoom/blob/master/src/Webinar.php)

uses default delete() method and fails when i try to delete via api