### PR TITLE
fixes php 8 issue

### DIFF
--- a/src/Exceptions/HttpException.php
+++ b/src/Exceptions/HttpException.php
@@ -3,10 +3,11 @@
 namespace MacsiDigital\API\Exceptions;
 
 use Exception;
+use Throwable;
 
 class HttpException extends Exception
 {
-    public function __construct($code = 0, $message, \Throwable $previous = null)
+    public function __construct($code = 0, $message = '', Throwable $previous = null)
     {
         parent::__construct('HTTP Request returned Status Code '.$code.'. '.$message);
     }


### PR DESCRIPTION
PHP message: PHP Deprecated:  Required parameter $message follows optional parameter $code in vendor/macsidigital/laravel-api-client/src/Exceptions/HttpException.php on line 9