### PR TITLE
Fix "Too few arguments" error for Resource class

### DIFF
--- a/src/Support/Resource.php
+++ b/src/Support/Resource.php
@@ -5,7 +5,6 @@ use MacsiDigital\API\Contracts\Entry;
 use MacsiDigital\API\Traits\HasAttributes;
 use MacsiDigital\API\Traits\HasRelationships;
 use MacsiDigital\API\Traits\HidesAttributes;
-use MacsiDigital\API\Support\Entry as EntryClass;
 
 class Resource
 {
@@ -15,7 +14,6 @@ class Resource
 
     public function __construct(Entry $client = null, $attributes = [])
     {
-        if (!$client) $this->client = new EntryClass;
         $this->client = $client;
 
         $this->syncOriginal();

--- a/src/Support/Resource.php
+++ b/src/Support/Resource.php
@@ -5,6 +5,7 @@ use MacsiDigital\API\Contracts\Entry;
 use MacsiDigital\API\Traits\HasAttributes;
 use MacsiDigital\API\Traits\HasRelationships;
 use MacsiDigital\API\Traits\HidesAttributes;
+use MacsiDigital\API\Support\Entry as EntryClass;
 
 class Resource
 {
@@ -12,8 +13,9 @@ class Resource
 
     public $client;
 
-    public function __construct(Entry $client, $attributes = [])
+    public function __construct(Entry $client = null, $attributes = [])
     {
+        if (!$client) $this->client = new EntryClass;
         $this->client = $client;
 
         $this->syncOriginal();


### PR DESCRIPTION
This fixes a critical error from the [laravel-zoom](https://github.com/MacsiDigital/laravel-zoom) package that was causing issues for many people. See [#116](https://github.com/MacsiDigital/laravel-zoom/issues/116) and [#121](https://github.com/MacsiDigital/laravel-zoom/issues/121).