### PR TITLE
Upgrade firebase/php-jwt to fix vulnerability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,17 +8,15 @@
     "homepage": "https://github.com/macsidigital/laravel-api-client",
     "license": "MIT",
     "type": "library",
-    "authors": [
-        {
-            "name": "Colin Hall",
-            "email": "colin@macsi.co.uk"
-        }
-    ],
+    "authors": [{
+        "name": "Colin Hall",
+        "email": "colin@macsi.co.uk"
+    }],
     "require": {
         "php": "^7.3|^8.0|^8.1",
         "nesbot/carbon": "^1.26.3 || ^2.0",
         "guzzlehttp/guzzle": "~7.0|~6.0|~5.0|~4.0",
-        "firebase/php-jwt": "^5.0",
+        "firebase/php-jwt": "^6.0",
         "illuminate/support": "^7.0|^8.0|^9.0|^10.0",
         "macsidigital/laravel-oauth2-client": "^1.2|^2.0"
     },

--- a/src/Support/Authentication/JWT.php
+++ b/src/Support/Authentication/JWT.php
@@ -2,17 +2,18 @@
 
 namespace MacsiDigital\API\Support\Authentication;
 
+use Firebase\JWT\Key;
 use Firebase\JWT\JWT as FirebaseJWT;
 
 class JWT
 {
     public static function generateToken($token, $secret)
     {
-        return FirebaseJWT::encode($token, $secret);
+        return FirebaseJWT::encode($token, $secret, 'HS256');
     }
 
     public static function decodeToken($jwt, $secret)
     {
-        return FirebaseJWT::decode($jwt, $secret, ['HS256']);
+        return FirebaseJWT::decode($jwt, new Key($secret, 'HS256'));
     }
 }


### PR DESCRIPTION
- Bumps the requirement for the package to v6.0 as prior versions have vulnerability [CVE-2021-46743](https://github.com/advisories/GHSA-8xf4-w7qw-pjjw)
- Makes the changes to JWT encoding/decoding as per the [upgrade guide](https://github.com/firebase/php-jwt/releases/tag/v6.0.0)
