### PR TITLE
Fix the `$dates` property usage that was deprecated

### DIFF
--- a/src/Traits/HasAttributes.php
+++ b/src/Traits/HasAttributes.php
@@ -49,7 +49,7 @@ trait HasAttributes
 
     public function getDates()
     {
-        return $this->dates;
+        return $this->dates ?? [];
     }
 
     /**

--- a/src/Traits/HasAttributes.php
+++ b/src/Traits/HasAttributes.php
@@ -47,7 +47,7 @@ trait HasAttributes
         return false;
     }
 
-    public function getDates()
+    public function getDates(): array
     {
         return $this->dates ?? [];
     }

--- a/src/Traits/HasAttributes.php
+++ b/src/Traits/HasAttributes.php
@@ -53,11 +53,7 @@ trait HasAttributes
             return $this->dates;
         }
 
-        $dates = \array_filter($this->getCasts(), function (string $cast) {
-            return $this->isDateCastable($cast);
-        });
-
-        return \array_keys($dates);
+        return [];
     }
 
     /**

--- a/src/Traits/HasAttributes.php
+++ b/src/Traits/HasAttributes.php
@@ -49,7 +49,6 @@ trait HasAttributes
 
     public function getDates(): array
     {
-        // For Laravel 7 and below
         if (\property_exists($this, 'dates')) {
             return $this->dates;
         }

--- a/src/Traits/HasAttributes.php
+++ b/src/Traits/HasAttributes.php
@@ -49,7 +49,16 @@ trait HasAttributes
 
     public function getDates(): array
     {
-        return $this->dates ?? [];
+        // For Laravel 7 and below
+        if (\property_exists($this, 'dates')) {
+            return $this->dates;
+        }
+
+        $dates = \array_filter($this->getCasts(), function (string $cast) {
+            return $this->isDateCastable($cast);
+        });
+
+        return \array_keys($dates);
     }
 
     /**


### PR DESCRIPTION
This PR fixes the following exception:

> in_array(): Argument # 2 ($haystack) must be of type array, null given

The `$dates` property in [`HasAttributes`](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php) was deprecated and is removed in Laravel 10. It also doesn't exist in some of the models such as `MacsiDigital\Zoom\MeetingSetting` and `MacsiDigital\Zoom\User`. The [`getDates`](https://github.com/MacsiDigital/laravel-api-client/blob/master/src/Traits/HasAttributes.php#L50) method is called in the [`isDateAttribute`](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L1076) method, which triggers the exception above.