### PR TITLE
Bugfix: 

### DIFF
--- a/src/Support/Resource.php
+++ b/src/Support/Resource.php
@@ -12,6 +12,8 @@ class Resource
 
     public $client;
 
+    protected static $ResourcesShouldPreventAccessingMissingAttributes = false;
+
     public function __construct(Entry $client = null, $attributes = [])
     {
         $this->client = $client;
@@ -19,6 +21,18 @@ class Resource
         $this->syncOriginal();
 
         $this->fill($attributes);
+    }
+
+
+    /**
+     * Determine if accessing missing attributes is disabled.
+     * Nested Requirement originating from the Laravel 10 HasAttributes Trait
+     *
+     * @return bool
+     */
+    public static function preventsAccessingMissingAttributes()
+    {
+        return static::$ResourcesShouldPreventAccessingMissingAttributes;
     }
 
     /**


### PR DESCRIPTION
After upgrading to Laravel 10, attempts to access attributes on a macsidigital/laravel-zoom Meeting throw undefined method exception for preventsAccessingMissingAttributes() - This is due the Macsi version of HasAttributes including the Laravel HasAttributes trait, which assumes this method exists when checking 'model' attribute access.

e.g.
[2025-11-13 11:19:25] local.ERROR: Call to undefined method MacsiDigital\Zoom\Meeting::preventsAccessingMissingAttributes() {"userId":4,"exception":"[object] (BadMethodCallException(code: 0): Call to un
defined method MacsiDigital\\Zoom\\Meeting::preventsAccessingMissingAttributes() at /var/www/html/vendor/macsidigital/laravel-api-client/src/Traits/ForwardsCalls.php:50)

Somewhere between Laravel 8 and 10, they have added static calls to preventsAccessingMissingAttributes whenever accessing an attribute (in my case $meeting->start_time). Laravel 10 implements this method in the abstract Eloquent/Model class but anything which implements the HasAttributes trait has an implicit dependency on this method being defined :-(

In this PR I've just copied the approach in Eloquent's Model Class and can confirm that it fixes the issue on my site.